### PR TITLE
Fix setHighPower() logic and over current protection settings

### DIFF
--- a/RFM9.c
+++ b/RFM9.c
@@ -337,12 +337,11 @@ void setHighPowerRegs(uint8_t onOff)
 void setHighPower(uint8_t onOff) 
 {
 	isRFM69HW = onOff;
-	if(isRFM69HW==0)
-	    writeReg(REG_OCP, RF_OCP_OFF);
-	else if(isRFM69HW==1) // turning ON
-	    writeReg(REG_PALEVEL, (readReg(REG_PALEVEL) & 0x1F) | RF_PALEVEL_PA1_ON | RF_PALEVEL_PA2_ON); // enable P1 & P2 amplifier stages
-	else
-	    writeReg(REG_PALEVEL, RF_PALEVEL_PA0_ON | RF_PALEVEL_PA1_OFF | RF_PALEVEL_PA2_OFF | powerLevel); // enable P0 only
+        writeReg(REG_OCP, isRFM69HW ? RF_OCP_OFF : RF_OCP_ON);
+        if(isRFM69HW == 1) // turning ON
+            writeReg(REG_PALEVEL, (readReg(REG_PALEVEL) & 0x1F) | RF_PALEVEL_PA1_ON | RF_PALEVEL_PA2_ON); // enable P1 & P2 amplifier stages
+        else
+            writeReg(REG_PALEVEL, RF_PALEVEL_PA0_ON | RF_PALEVEL_PA1_OFF | RF_PALEVEL_PA2_OFF | powerLevel); // enable P0 only
 }
 
 // get the received signal strength indicator (RSSI)


### PR DESCRIPTION
As far as I can tell, the way `setHighPower()` worked before this PR would result in the `else` block never being hit.  Also, this library was turning OCP off when our module is _not_ an RFM69HW, whereas the library this code is based on turns OCP off when our module _is_ an RFM69HW. 

https://github.com/LowPowerLab/RFM69/blob/2602559dd0b961f9108033563bd0e296887a4049/RFM69.cpp#L510 