### PR TITLE
Add atmega328/p support

### DIFF
--- a/RFM69.c
+++ b/RFM69.c
@@ -37,10 +37,10 @@
 // **********************************************************************************
 
 #include <avr/interrupt.h>
-#include "spi.c"
+#include "spi.h"
 #include "RFM69registers.h"
 #include "RFM69.h"
-#include "get_millis.c"
+#include "get_millis.h"
 
 volatile uint8_t DATALEN;
 volatile uint8_t SENDERID;
@@ -337,12 +337,12 @@ void setHighPowerRegs(uint8_t onOff)
 void setHighPower(uint8_t onOff) 
 {
     isRFM69HW = onOff;
-    writeReg(REG_OCP, isRFM69HW ? RF_OCP_OFF : RF_OCP_ON);
+    writeReg(REG_OCP, isRFM69HW ? RF_OCP_OFF : RF_OCP_ON);
 
     if (isRFM69HW == 1) // turning ON
-        writeReg(REG_PALEVEL, (readReg(REG_PALEVEL) & 0x1F) | RF_PALEVEL_PA1_ON | RF_PALEVEL_PA2_ON); // enable P1 & P2 amplifier stages
+        writeReg(REG_PALEVEL, (readReg(REG_PALEVEL) & 0x1F) | RF_PALEVEL_PA1_ON | RF_PALEVEL_PA2_ON); // enable P1 & P2 amplifier stages
     else
-        writeReg(REG_PALEVEL, RF_PALEVEL_PA0_ON | RF_PALEVEL_PA1_OFF | RF_PALEVEL_PA2_OFF | powerLevel); // enable P0 only
+        writeReg(REG_PALEVEL, RF_PALEVEL_PA0_ON | RF_PALEVEL_PA1_OFF | RF_PALEVEL_PA2_OFF | powerLevel); // enable P0 only
 }
 
 // get the received signal strength indicator (RSSI)

--- a/RFM69.c
+++ b/RFM69.c
@@ -42,7 +42,6 @@
 #include "RFM69.h"
 #include "get_millis.c"
 
-volatile uint8_t DATA[RF69_MAX_DATA_LEN];  // recv/xmit buf, including header & crc bytes
 volatile uint8_t DATALEN;
 volatile uint8_t SENDERID;
 volatile uint8_t TARGETID;                 // should match _address

--- a/RFM69.c
+++ b/RFM69.c
@@ -36,6 +36,8 @@
 // DIO0 -> PE5 that is INT5, an interrupt enabled pin
 // **********************************************************************************
 
+
+#include <avr/io.h>
 #include <avr/interrupt.h>
 #include "spi.h"
 #include "RFM69registers.h"
@@ -447,6 +449,7 @@ uint8_t receiveDone()
         return 0;
     }
     receiveBegin();
+    sei();
     return 0;
 }
 

--- a/RFM69.h
+++ b/RFM69.h
@@ -48,6 +48,8 @@
 
 #   define INT_DDR               DDRD
 #   define INT_PORT             PORTD
+#   define INT_PIN               PIND
+#   define INT_pin_num              2
 #   define INT_PIN_n              PD2
 #   define INTn                  INT0
 #   define ISCn0                ISC00
@@ -63,6 +65,8 @@
 
 #   define INT_DDR               DDRE
 #   define INT_PORT             PORTE
+#   define INT_PIN               PINE
+#   define INT_pin_num              5
 #   define INT_PIN_n              PE5
 #   define INTn                  INT5
 #   define ISCn0                ISC50

--- a/RFM69.h
+++ b/RFM69.h
@@ -86,7 +86,10 @@
 // TWS: define CTLbyte bits
 #define RFM69_CTL_SENDACK   0x80
 #define RFM69_CTL_REQACK    0x40
-    
+
+// Global Variables
+volatile uint8_t DATA[RF69_MAX_DATA_LEN];  // recv/xmit buf, including header & crc bytes
+
 // Function Declerations
 void rfm69_init(uint16_t freqBand, uint8_t nodeID, uint8_t networkID=33);
 void setAddress(uint8_t addr);

--- a/RFM69.h
+++ b/RFM69.h
@@ -41,17 +41,34 @@
 #define RFM69_h
 
 // Definitions
-#define SS_DDR                DDRB
-#define SS_PORT              PORTB
-#define SS_PIN                 PB0
+#if defined (__AVR_ATmega328__) || defined (__AVR_ATmega328P__)
+    #define SS_DDR                DDRB
+    #define SS_PORT              PORTB
+    #define SS_PIN                 PB2
 
-#define INT_DDR               DDRE
-#define INT_PORT             PORTE
-#define INT_PIN                PE5
-#define INTn                  INT5
-#define ISCn0                ISC50
-#define ISCn1                ISC51
-#define INT_VECT         INT5_vect
+    #define INT_DDR               DDRD
+    #define INT_PORT             PORTD
+    #define INT_PIN                PD2
+    #define INTn                  INT0
+    #define ISCn0                ISC00
+    #define ISCn1                ISC01
+    #define INT_VECT         INT0_vect
+
+#elif defined (__AVR_ATmega64__)
+    #define SS_DDR                DDRB
+    #define SS_PORT              PORTB
+    #define SS_PIN                 PB0
+
+    #define INT_DDR               DDRE
+    #define INT_PORT             PORTE
+    #define INT_PIN                PE5
+    #define INTn                  INT5
+    #define ISCn0                ISC50
+    #define ISCn1                ISC51
+    #define INT_VECT         INT5_vect
+#endif
+
+
 
 #define RF69_MAX_DATA_LEN       61  // to take advantage of the built in AES/CRC we want to limit the frame size to the internal FIFO size (66 bytes - 3 bytes overhead - 2 bytes crc)
 #define CSMA_LIMIT             -90 // upper RX signal sensitivity threshold in dBm for carrier sense access

--- a/RFM69.h
+++ b/RFM69.h
@@ -42,30 +42,34 @@
 
 // Definitions
 #if defined (__AVR_ATmega328__) || defined (__AVR_ATmega328P__)
-    #define SS_DDR                DDRB
-    #define SS_PORT              PORTB
-    #define SS_PIN                 PB2
+#   define SS_DDR                DDRB
+#   define SS_PORT              PORTB
+#   define SS_PIN                 PB2
 
-    #define INT_DDR               DDRD
-    #define INT_PORT             PORTD
-    #define INT_PIN                PD2
-    #define INTn                  INT0
-    #define ISCn0                ISC00
-    #define ISCn1                ISC01
-    #define INT_VECT         INT0_vect
+#   define INT_DDR               DDRD
+#   define INT_PORT             PORTD
+#   define INT_PIN_n              PD2
+#   define INTn                  INT0
+#   define ISCn0                ISC00
+#   define ISCn1                ISC01
+#   define INT_VECT         INT0_vect
+
+#   define EICRn               EICRA
 
 #elif defined (__AVR_ATmega64__)
-    #define SS_DDR                DDRB
-    #define SS_PORT              PORTB
-    #define SS_PIN                 PB0
+#   define SS_DDR                DDRB
+#   define SS_PORT              PORTB
+#   define SS_PIN                 PB0
 
-    #define INT_DDR               DDRE
-    #define INT_PORT             PORTE
-    #define INT_PIN                PE5
-    #define INTn                  INT5
-    #define ISCn0                ISC50
-    #define ISCn1                ISC51
-    #define INT_VECT         INT5_vect
+#   define INT_DDR               DDRE
+#   define INT_PORT             PORTE
+#   define INT_PIN_n              PE5
+#   define INTn                  INT5
+#   define ISCn0                ISC50
+#   define ISCn1                ISC51
+#   define INT_VECT         INT5_vect
+
+#   define EICRn               EICRB
 #endif
 
 

--- a/RFM69.h
+++ b/RFM69.h
@@ -91,29 +91,29 @@
 volatile uint8_t DATA[RF69_MAX_DATA_LEN];  // recv/xmit buf, including header & crc bytes
 
 // Function Declerations
-void rfm69_init(uint16_t freqBand, uint8_t nodeID, uint8_t networkID=33);
+void rfm69_init(uint16_t freqBand, uint8_t nodeID, uint8_t networkID);
 void setAddress(uint8_t addr);
 void setNetwork(uint8_t networkID);
 uint8_t canSend();
-void send(uint8_t toAddress, const void* buffer, uint8_t bufferSize, uint8_t requestACK=0);
+void send(uint8_t toAddress, const void* buffer, uint8_t bufferSize, uint8_t requestACK);
 uint8_t sendWithRetry(uint8_t toAddress, const void* buffer, uint8_t bufferSize, uint8_t retries, uint8_t retryWaitTime);
 uint8_t ACKRequested();
 uint8_t ACKReceived(uint8_t fromNodeID);
 void receiveBegin();
 uint8_t receiveDone();
-void sendACK(const void* buffer = "", uint8_t bufferSize=0);
+void sendACK(const void* buffer, uint8_t bufferSize);
 uint32_t getFrequency();
 void setFrequency(uint32_t freqHz);
 void encrypt(const char* key);
-int16_t readRSSI(uint8_t forceTrigger=0);
-void setHighPower(uint8_t onOFF=1);           // has to be called after initialize() for RFM69HW
+int16_t readRSSI(uint8_t forceTrigger);
+void setHighPower(uint8_t onOFF);           // has to be called after initialize() for RFM69HW
 void setPowerLevel(uint8_t level);            // reduce/increase transmit power level
 void sleep();
-uint8_t readTemperature(uint8_t calFactor=0); // get CMOS temperature (8bit)
+uint8_t readTemperature(uint8_t calFactor); // get CMOS temperature (8bit)
 void rcCalibration();                         // calibrate the internal RC oscillator for use in wide temperature variations - see datasheet section [4.3.5. RC Timer Accuracy]
 uint8_t readReg(uint8_t addr);
 void writeReg(uint8_t addr, uint8_t val);
-void sendFrame(uint8_t toAddress, const void* buffer, uint8_t size, uint8_t requestACK=0, uint8_t sendACK=0);
+void sendFrame(uint8_t toAddress, const void* buffer, uint8_t size, uint8_t requestACK, uint8_t sendACK);
 void setMode(uint8_t mode);
 void setHighPowerRegs(uint8_t onOff);
 void promiscuous(uint8_t onOff);

--- a/RFM69.h
+++ b/RFM69.h
@@ -36,6 +36,7 @@
 // DIO0 -> PE5 that is INT5, an interrupt enabled pin
 // **********************************************************************************
 
+#include <avr/io.h>
 
 #ifndef RFM69_h
 #define RFM69_h

--- a/get_millis.c
+++ b/get_millis.c
@@ -19,7 +19,7 @@ void millis_init()
     sei();
     
     // Enable the compare match interrupt
-    TIMSK |= (1 << OCIE1A);
+    TIMSK1 |= (1 << OCIE1A);
 }
 
 unsigned long millis()
@@ -37,4 +37,3 @@ ISR (TIMER1_COMPA_vect)
 {
     timer1_millis++;
 }
-

--- a/spi.c
+++ b/spi.c
@@ -24,6 +24,7 @@
     $Id$
 */
 
+#include <avr/io.h>
 #include "spi.h"
 
 void spi_init()

--- a/spi.h
+++ b/spi.h
@@ -27,12 +27,21 @@
 #ifndef SPI_h
 #define SPI_h
 
-#define SPI_DDR   DDRB
-//define pin number: atmega64
-#define MISO         3
-#define MOSI         2
-#define SCK          1
-#define SS           0
+
+#if defined (__AVR_ATmega328__) || defined (__AVR_ATmega328P__)
+    #define SPI_DDR   DDRB
+    #define MISO         4
+    #define MOSI         3
+    #define SCK          5
+    #define SS           2
+
+#elif defined (__AVR_ATmega64__)
+    #define SPI_DDR   DDRB
+    #define MISO         3
+    #define MOSI         2
+    #define SCK          1
+    #define SS           0
+#endif
 
 void spi_init();
 void spi_transfer_sync (uint8_t * dataout, uint8_t * datain, uint8_t len);


### PR DESCRIPTION
I have added support for the atmega328/p. I believe I have retained support for the atmega64.
In order to do this I refactored some hard coded registers.

I also removed some "default parameter values" which are not actually standard C. These edits allow the code to be complied with avr-gcc and not just avr-g++.

There are a few other code refactors as well to clean up the code.

I have tested this code and have it running on the atmega328.